### PR TITLE
Fix faulty form-body-parsing

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -42,9 +42,10 @@ export default (options = {
 
 			// parse key-value pairs
 			let match
-			while ([key, value] = keyValueRegex.exec(raw))
-				result[sanitize(key)] = sanitize(value)
-
+			while (match = keyValueRegex.exec(raw)) {
+				const [,key, value] = match.map(sanitize)
+				result[key] = value
+			}
 			// set body
 			request.body = result
 


### PR DESCRIPTION
1) Regexp.exec returns (match, [group1, [group2 ...]])
2) Regexp.exec returns null if there are no matches; we can't destructure null